### PR TITLE
Add asset categories and asset contexts

### DIFF
--- a/src/assets/artwork/4810866d-ae52-430a-94d9-24e9365d94fc.json
+++ b/src/assets/artwork/4810866d-ae52-430a-94d9-24e9365d94fc.json
@@ -1,5 +1,5 @@
 {
   "id": "4810866d-ae52-430a-94d9-24e9365d94fc",
   "name": "Sitting Woman",
-  "category_ids": []
+  "category_ids": ["44ab10b4-aafc-40ea-a5f9-42655353757b"]
 }

--- a/src/assets/artwork/82eb0c6a-6f93-4d94-9a04-9ca70c256844.json
+++ b/src/assets/artwork/82eb0c6a-6f93-4d94-9a04-9ca70c256844.json
@@ -1,5 +1,5 @@
 {
   "id": "82eb0c6a-6f93-4d94-9a04-9ca70c256844",
   "name": "Sitting Cat",
-  "category_ids": []
+  "category_ids": ["aeddbb22-f1bc-45c7-91ee-db0d30c5e974"]
 }

--- a/src/assets/artwork/9b8376e6-e54b-4ad3-a95a-a1f1a45a3171.json
+++ b/src/assets/artwork/9b8376e6-e54b-4ad3-a95a-a1f1a45a3171.json
@@ -1,5 +1,5 @@
 {
   "id": "9b8376e6-e54b-4ad3-a95a-a1f1a45a3171",
   "name": "Moped",
-  "category_ids": []
+  "category_ids": ["e7c60817-ec70-44fe-8c84-7de2069159fb"]
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,22 @@
+﻿import { ArtAssetCategory } from './types'
+
+/**
+ * The list of asset categories used in asset metadata JSON files
+ */
+export const ASSET_CATEGORIES: ArtAssetCategory[] = [
+  {
+    id: '44ab10b4-aafc-40ea-a5f9-42655353757b',
+    name: 'People',
+    icon: 'asset-category-people'
+  },
+  {
+    id: 'aeddbb22-f1bc-45c7-91ee-db0d30c5e974',
+    name: 'Animals',
+    icon: 'asset-category-animal'
+  },
+  {
+    id: 'e7c60817-ec70-44fe-8c84-7de2069159fb',
+    name: 'Vehicles',
+    icon: 'asset-category-vehicle'
+  }
+]

--- a/src/contexts/assets.tsx
+++ b/src/contexts/assets.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useState } from 'react'
+import { art_assets } from 'virtual:art_assets'
+
+const ArtAssetsContext = createContext(art_assets)
+
+interface ArtAssetsProviderProps {
+  children?: React.ReactNode
+}
+
+/** Provider which could be updated to fetch assets from a remote location */
+export function ArtAssetsProvider({ children }: ArtAssetsProviderProps) {
+  const [assets] = useState(art_assets)
+
+  return (
+    <ArtAssetsContext.Provider value={assets}>
+      {children}
+    </ArtAssetsContext.Provider>
+  )
+}
+
+/** Get the app's current list of art assets */
+export function useArtAssets() {
+  const context = useContext(ArtAssetsContext)
+  if (context == undefined)
+    throw new Error('Unable to use art assets outside of component')
+  return context
+}

--- a/src/contexts/assets.tsx
+++ b/src/contexts/assets.tsx
@@ -1,5 +1,10 @@
 import React, { createContext, useContext, useState } from 'react'
 import { art_assets } from 'virtual:art_assets'
+import { ASSET_CATEGORIES } from '../constants'
+
+/**
+ * Art Assets
+ */
 
 const ArtAssetsContext = createContext(art_assets)
 
@@ -23,5 +28,19 @@ export function useArtAssets() {
   const context = useContext(ArtAssetsContext)
   if (context == undefined)
     throw new Error('Unable to use art assets outside of component')
+  return context
+}
+
+/**
+ * Asset Categories
+ */
+
+const AssetCategoriesContext = createContext(ASSET_CATEGORIES)
+
+/** Get the app's current list of asset categories */
+export function useAssetCategories() {
+  const context = useContext(AssetCategoriesContext)
+  if (context == undefined)
+    throw new Error('Unable to use asset categories outide of component')
   return context
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,17 @@
 ﻿import { INode } from 'svgson'
 
+/** Category information for an art asset. */
+export type ArtAssetCategory = {
+  /** The UUID of the art asset category. */
+  id: string
+
+  /** The name of the art asset category. */
+  name: string
+
+  /** Icon associated with this art asset category. */
+  icon: string
+}
+
 /** An individual art asset. */
 export interface ArtAsset {
   /** The UUID of the art asset. */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+// Add virtual import types
+declare module 'virtual:art_assets' {
+  import { ArtAsset } from './types'
+
+  /** Art assets compiled from the `/src/assets/artwork` folder */
+  export const art_assets: ArtAsset[]
+}

--- a/tests/contexts/asset.test.tsx
+++ b/tests/contexts/asset.test.tsx
@@ -1,6 +1,6 @@
 ﻿import { describe, expect, it } from 'vitest'
 import { renderHook } from '../utils'
-import { useArtAssets } from '../../src/contexts/assets'
+import { useArtAssets, useAssetCategories } from '../../src/contexts/assets'
 
 describe('Assets Contexts', () => {
   describe('Art Assets Context', () => {
@@ -11,6 +11,18 @@ describe('Assets Contexts', () => {
       expect(result.current.length).toBeGreaterThan(0) // Make sure there is something in the array
       expect(Object.keys(result.current[0])).toEqual(
         expect.arrayContaining(['id', 'name', 'src', 'content', 'category_ids']) // Make sure the array contains an art asset object
+      )
+    })
+  })
+
+  describe('Asset Categories Context', () => {
+    it('should provide a list of categories', () => {
+      const { result } = renderHook(() => useAssetCategories())
+
+      expect(Array.isArray(result.current)).toBeTruthy() // Make sure the hook returns an array
+      expect(result.current.length).toBeGreaterThan(0) // Make sure there is something in the array
+      expect(Object.keys(result.current[0])).toEqual(
+        expect.arrayContaining(['id', 'name', 'icon']) // Make sure the array contains an asset category object
       )
     })
   })

--- a/tests/contexts/asset.test.tsx
+++ b/tests/contexts/asset.test.tsx
@@ -1,0 +1,17 @@
+﻿import { describe, expect, it } from 'vitest'
+import { renderHook } from '../utils'
+import { useArtAssets } from '../../src/contexts/assets'
+
+describe('Assets Contexts', () => {
+  describe('Art Assets Context', () => {
+    it('should provide an array of art assets', () => {
+      const { result } = renderHook(() => useArtAssets())
+
+      expect(Array.isArray(result.current)).toBeTruthy() // Make sure the hook returns an array
+      expect(result.current.length).toBeGreaterThan(0) // Make sure there is something in the array
+      expect(Object.keys(result.current[0])).toEqual(
+        expect.arrayContaining(['id', 'name', 'src', 'content', 'category_ids']) // Make sure the array contains an art asset object
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds asset categories to the project in the form of a constant, as well as React contexts that provide the artwork assets and asset category collections to anywhere within the App. Additionally, the added categories are assigned to the existing assets.

## Usage

You can now use `useArtAssets()` and `useAssetCategories()` to access these collections. For example:

```tsx
export function AllCategories() {
  const asset_categories = useAssetCategories()
  return <div>{asset_categories.map(category => category.name)}</div>
}
```