### PR TITLE
Add TextInput component

### DIFF
--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -1,0 +1,54 @@
+﻿import React from 'react'
+import { SvgIcon } from '../media/SvgIcon'
+
+interface TextInputProps {
+  /** Name of the icon to show on the left hand side */
+  leftIcon?: string
+
+  /** Name of the icon to show on the right hand side */
+  rightIcon?: string
+}
+
+/** Basic text input component. */
+export function TextInput({
+  leftIcon,
+  rightIcon,
+  className,
+  ...props
+}: TextInputProps & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div
+      className={
+        className +
+        ' group flex items-center px-1/2 py-1/4 rounded-1/4 text-white border border-neutral-650 bg-neutral-850 initial:w-full focus-within:z-10 focus-within:outline-none focus-within:ring-1/8 focus-within:ring-blue-500 focus-within:!border-blue-400'
+      }
+    >
+      {leftIcon != undefined && (
+        <div className="flex items-center">
+          <SvgIcon
+            name={leftIcon}
+            className="fill-current mr-1/4 h-[1.5em] -m-1/4"
+            data-testid="text-left-icon"
+          />
+        </div>
+      )}
+      <div className="flex-1">
+        <input
+          type="text"
+          size={0}
+          className="border-0 p-0 bg-transparent focus:ring-0 focus:outline-none w-full placeholder:text-neutral-450"
+          {...props}
+        />
+      </div>
+      {rightIcon != undefined && (
+        <div className="flex items-center">
+          <SvgIcon
+            name={rightIcon}
+            className="fill-current ml-1/4 h-[1.5em] -m-1/4"
+            data-testid="text-right-icon"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tests/components/inputs/TextInput.test.tsx
+++ b/tests/components/inputs/TextInput.test.tsx
@@ -1,0 +1,58 @@
+﻿import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, userEvent, screen } from '../../utils'
+
+import { TextInput } from '../../../src/components/inputs/TextInput'
+
+describe('Text Input Component', () => {
+  it('should take a default value', () => {
+    const default_value = 'Test Value'
+    const text_input = render(<TextInput defaultValue={default_value} />)
+    const input = text_input.getByRole('textbox')
+
+    expect(input).toHaveValue(default_value)
+  })
+
+  it('should call `onInput` when typed in', async () => {
+    const test_input = 'test input'
+    const event_handlers = {
+      handleInput() {
+        return undefined
+      }
+    }
+
+    const input_event_spy = vi.spyOn(event_handlers, 'handleInput')
+    const user = userEvent.setup() // Set up a session with user-event
+
+    render(<TextInput onInput={event_handlers.handleInput} />)
+
+    await user.type(screen.getByRole('textbox'), test_input)
+
+    expect(input_event_spy).toHaveBeenCalledTimes(test_input.length)
+  })
+
+  it('should accept a placeholder', () => {
+    const placeholder_value = 'test placeholder'
+    render(<TextInput placeholder={placeholder_value} />)
+    const input = screen.queryByPlaceholderText(placeholder_value)
+    expect(input).toBeTruthy()
+  })
+
+  it('should display an icon on the left', () => {
+    const icon_value = 'test-icon'
+    const button = render(<TextInput leftIcon={icon_value} />)
+
+    const leftIcon = button.queryByTestId('text-left-icon')
+
+    expect(leftIcon).toBeTruthy()
+  })
+
+  it('should display an icon on the right', () => {
+    const icon_value = 'test-icon'
+    const button = render(<TextInput rightIcon={icon_value} />)
+
+    const rightIcon = button.queryByTestId('text-right-icon')
+
+    expect(rightIcon).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds a styled `TextInput` component. It behaves closely to a normal HTML text input, but with optional props to display an icon on the left or right side.

## Usage

All normal HTML text input attributes are passed along to this component's internal text input. Use an icon name in the `leftIcon` or `rightIcon` props to display that icon.

Example:

```tsx
export function App() {
  return <TextInput leftIcon="search" placeholder="Search..." />
}
```