### PR TITLE
Build stage from project state and add transformable stage object that renders art assets

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,8 +1,13 @@
-﻿import React from 'react'
+import React from 'react'
 import { PaneHeading } from '../layout/PaneHeading'
 import { EditorAssetPane } from './AssetPane'
 import { Stage, Layer, Rect } from 'react-konva'
-import { useAppSelector } from '../../hooks'
+import { useAppDispatch, useAppSelector } from '../../hooks'
+import { isArtAssetStageObject } from '../../utils'
+import { EditorArtAssetStageObject } from './objects/ArtAssetStageObject'
+import { useArtAssets } from '../../contexts/assets'
+import { ArtAsset, ArtAssetStageObject, StageObjectType } from '../../types'
+import { addObject } from '../../stores/project'
 
 /**
  * Creates an instance of the visual editor.
@@ -12,6 +17,44 @@ export function Editor({
   ...props
 }: React.HtmlHTMLAttributes<HTMLDivElement>) {
   const project = useAppSelector(state => state.project)
+  const dispatch = useAppDispatch()
+  const art_assets = useArtAssets()
+
+  /**
+   * Asset pane item selection handling
+   */
+  function handleAssetClick(asset: ArtAsset) {
+    dispatch(
+      addObject({
+        type: StageObjectType.ART_ASSET,
+        x: 0,
+        y: 0,
+        scale: { x: 1, y: 1 },
+        rotation: 0,
+        asset_id: asset.id
+      } as Omit<ArtAssetStageObject, 'id'>)
+    )
+  }
+
+  /**
+   * Build stage content
+   */
+  const stage_content = project.stage.map(stage_object => {
+    if (isArtAssetStageObject(stage_object)) {
+      return (
+        <EditorArtAssetStageObject
+          key={stage_object.id}
+          x={stage_object.x}
+          y={stage_object.y}
+          scale={stage_object.scale}
+          rotation={stage_object.rotation}
+          art_asset={art_assets.find(
+            asset => asset.id == stage_object.asset_id
+          )}
+        />
+      )
+    }
+  })
 
   return (
     <div className={className + ' h-full flex'} {...props}>
@@ -19,7 +62,7 @@ export function Editor({
       <div className="flex flex-col w-14 bg-neutral-850">
         {/* Assets Pane */}
         <PaneHeading>Assets</PaneHeading>
-        <EditorAssetPane className="flex-1" />
+        <EditorAssetPane className="flex-1" onAssetClick={handleAssetClick} />
       </div>
 
       {/* Main Viewport */}
@@ -37,7 +80,7 @@ export function Editor({
               fill="white"
             />
           </Layer>
-          <Layer data-testid="project-content-layer"></Layer>
+          <Layer data-testid="project-content-layer">{stage_content}</Layer>
         </Stage>
       </div>
     </div>

--- a/src/components/editor/objects/ArtAssetStageObject.tsx
+++ b/src/components/editor/objects/ArtAssetStageObject.tsx
@@ -1,0 +1,73 @@
+import { Group as GroupElement, GroupConfig } from 'konva/lib/Group'
+import { KonvaEventObject } from 'konva/lib/Node'
+import { Transformer as TransformerElement } from 'konva/lib/shapes/Transformer'
+import React, { useEffect, useRef } from 'react'
+import { Group, Transformer } from 'react-konva'
+import { ArtAsset, StageObject } from '../../../types'
+import { svgsonToKonvaPaths } from '../utils'
+
+interface EditorArtAssetStageObjectProps {
+  /** The art asset to render. */
+  art_asset: ArtAsset
+
+  /** Whether or not the stage object is selected. */
+  isSelected?: boolean
+
+  /** Called when the stage object is selected. */
+  onSelect?: () => void
+
+  /** Called when the stage object is dragged or transformed. */
+  onChange?: (e: Omit<StageObject, 'id' | 'type'>) => void
+}
+
+/** A stage object that renders an art asset. */
+export function EditorArtAssetStageObject({
+  art_asset,
+  isSelected,
+  onSelect,
+  onChange,
+  ...props
+}: EditorArtAssetStageObjectProps & GroupConfig) {
+  const group_ref = useRef<GroupElement>(null)
+  const transformer_ref = useRef<TransformerElement>(null)
+
+  // Manually attach the transformer nodes
+  useEffect(() => {
+    if (isSelected && group_ref.current && transformer_ref.current) {
+      // we need to attach transformer manually
+      transformer_ref.current.nodes([group_ref.current])
+      transformer_ref.current.getLayer()?.batchDraw()
+    }
+  }, [isSelected])
+
+  // Emit change events after drag or transform
+  function handleChangeUpdate(e: KonvaEventObject<any>) {
+    if (onChange) {
+      const shape = e.target
+      onChange({
+        x: shape.x(),
+        y: shape.y(),
+        scale: shape.scale() || { x: 1, y: 1 },
+        rotation: shape.rotation()
+      })
+    }
+  }
+
+  return (
+    <React.Fragment>
+      <Group
+        ref={group_ref}
+        onClick={onSelect}
+        onTap={onSelect}
+        draggable
+        onDragStart={onSelect}
+        onDragEnd={handleChangeUpdate}
+        onTransformEnd={handleChangeUpdate}
+        {...props}
+      >
+        {svgsonToKonvaPaths(art_asset.content)}
+      </Group>
+      {isSelected && <Transformer ref={transformer_ref}></Transformer>}
+    </React.Fragment>
+  )
+}

--- a/src/components/editor/utils.tsx
+++ b/src/components/editor/utils.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Path } from 'react-konva'
+import { INode } from 'svgson'
+import { LineCap, LineJoin } from 'konva/lib/Shape'
+
+/** Convert SVGSON AST to Konva Path components */
+export function svgsonToKonvaPaths(svgson: INode) {
+  return svgson.children.reduce<React.ReactNode[]>((paths, child, i) => {
+    if (child.name == 'path') {
+      const {
+        d,
+        opacity,
+        fill,
+        stroke,
+        'stroke-width': strokeWidth,
+        'line-join': lineJoin,
+        'line-cap': lineCap
+      } = child.attributes
+
+      paths.push(
+        <Path
+          key={i}
+          data={d}
+          opacity={opacity ? parseFloat(opacity) : 1}
+          fill={fill == 'none' ? undefined : fill}
+          stroke={stroke == 'none' ? undefined : stroke}
+          strokeWidth={strokeWidth ? parseFloat(strokeWidth) : 0}
+          lineJoin={lineJoin as LineJoin}
+          lineCap={lineCap as LineCap}
+        />
+      )
+    }
+    return paths
+  }, [])
+}


### PR DESCRIPTION
## Summary

This PR introduces the ability for art assets to be added to the project state by clicking an art asset menu item in the asset pane. The project state is built and rendered to the stage. Stage objects can be selected and transformed. The main canvas and viewport can be clicked to deselect the currently selected object.

## Note about SVG rendering support

Currently only root-level `path` elements from an SVGSON AST are converted into Konva Paths.