### PR TITLE
Add drag from assets pane and drop onto stage

### DIFF
--- a/src/components/editor/AssetPane.tsx
+++ b/src/components/editor/AssetPane.tsx
@@ -86,6 +86,7 @@ export function EditorAssetPane({
   function handleDragStart(e: ReactDragEvent, asset: ArtAsset) {
     // Create a ghost image of the asset
     const ghost = document.createElement('img')
+    ghost.dataset.testid = 'asset-ghost'
     ghost.src = asset.src
 
     // Position the ghost absolutely, center the ghost under the element origin, and make sure there are no pointer events so it doesn't interfere with drag events

--- a/src/components/editor/AssetPane.tsx
+++ b/src/components/editor/AssetPane.tsx
@@ -129,7 +129,7 @@ export function EditorAssetPane({
     // Store the asset data using the drag events data transfer
     e.dataTransfer.setData(
       'text/plain',
-      `${asset.id}:${ghost.width}:${ghost.height}` // Serialize the asset data as ASSET_ID:WIDTH:HEIGHT
+      `${asset.id}:${asset.width}:${asset.height}` // Serialize the asset data as ASSET_ID:WIDTH:HEIGHT
     )
   }
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,4 +1,5 @@
 ﻿import React, {
+  DragEvent as ReactDragEvent,
   MouseEvent as ReactMouseEvent,
   TouchEvent as ReactTouchEvent,
   useRef,
@@ -95,6 +96,39 @@ export function Editor({
     }
   })
 
+  /**
+   * Drop handling
+   */
+  function handleDrop(e: ReactDragEvent) {
+    if (stage_ref.current) {
+      e.preventDefault()
+
+      stage_ref.current.setPointersPositions(e)
+      const [asset_id, width, height] = e.dataTransfer
+        .getData('text/plain')
+        .split(':') // Deserialize the data transfer object
+
+      // Make sure there is an asset by this ID in the assets list and create the object
+      if (asset_id && art_assets.find(asset => asset.id == asset_id)) {
+        const { x, y } = stage_ref.current.getPointerPosition() || {
+          x: 0,
+          y: 0
+        }
+
+        dispatch(
+          addObject({
+            type: StageObjectType.ART_ASSET,
+            x: x - parseFloat(width) / 2,
+            y: y - parseFloat(height) / 2,
+            scale: { x: 1, y: 1 },
+            rotation: 0,
+            asset_id
+          } as ArtAssetStageObject)
+        )
+      }
+    }
+  }
+
   return (
     <div className={className + ' h-full flex'} {...props}>
       {/* Left Pane */}
@@ -109,6 +143,8 @@ export function Editor({
         className="flex-1 flex items-center justify-center"
         onMouseDown={checkOutsideStageAndDeselect}
         onTouchStart={checkOutsideStageAndDeselect}
+        onDragOver={e => e.preventDefault()}
+        onDrop={handleDrop}
       >
         <Stage
           ref={stage_ref}

--- a/src/lib/assets-plugin.ts
+++ b/src/lib/assets-plugin.ts
@@ -50,6 +50,8 @@ export function assetsPlugin({
           art_assets.push({
             id,
             name,
+            width: parseFloat(asset_json_content.attributes.width),
+            height: parseFloat(asset_json_content.attributes.height),
             src: asset_file.substring(1), // Swallow the initial `.` in the path, e.g. `./src` -> `/src`
             content: asset_json_content,
             category_ids

--- a/src/main.css
+++ b/src/main.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 html, body, #root {
+	overflow: hidden;
 	height: 100%;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,12 @@ export interface ArtAsset {
   /** The name of the art asset. */
   name: string
 
+  /** The width of the art asset. */
+  width: number
+
+  /** The height of the art asset. */
+  height: number
+
   /** An array of category UUIDs assigned to the art asset. */
   category_ids: string[]
 

--- a/tests/assets-plugin.test.ts
+++ b/tests/assets-plugin.test.ts
@@ -12,7 +12,7 @@ describe('Assets Vite Plugin', () => {
   const virtual_module = 'virtual:art_assets'
   it('should load all assets successfully and export them as a virtual module', async () => {
     // Expect to find a single art asset compiled from the files found in `./fixtures/artwork`
-    const expected_export_structure = `[{"id":"82134889-ac55-4eea-8f6a-618699fbbb6b","name":"Some Asset","src":"/tests/fixtures/artwork/some-asset.svg","content":{"name":"svg","type":"element","value":"","attributes":{"height":"50","width":"50","xmlns":"http://www.w3.org/2000/svg"},"children":[]},"category_ids":[]}]`
+    const expected_export_structure = `[{"id":"82134889-ac55-4eea-8f6a-618699fbbb6b","name":"Some Asset","width":50,"height":50,"src":"/tests/fixtures/artwork/some-asset.svg","content":{"name":"svg","type":"element","value":"","attributes":{"height":"50","width":"50","xmlns":"http://www.w3.org/2000/svg"},"children":[]},"category_ids":[]}]`
 
     const assets_plugin = assetsPlugin({
       artwork_dir: './tests/fixtures/artwork'

--- a/tests/components/editor/AssetPane.test.tsx
+++ b/tests/components/editor/AssetPane.test.tsx
@@ -1,5 +1,5 @@
 ﻿import React from 'react'
-import { render, screen, userEvent } from '../../utils'
+import { render, screen, userEvent, fireEvent } from '../../utils'
 import { describe, expect, it, vi } from 'vitest'
 import {
   ArtAssetsContext,
@@ -92,5 +92,28 @@ describe('Editor Asset Pane Component', () => {
     await userEvent.type(asset_search_input, 'Second') // Type the string `Second` in order to include only the asset with `Second` in its name
 
     expect(main_list.children).toHaveLength(1) // There should now only be one asset listed
+  })
+
+  it('should show a ghost image of the asset when an asset menu item is dragged', () => {
+    render(
+      <ArtAssetsContext.Provider value={art_assets}>
+        <EditorAssetPane />
+      </ArtAssetsContext.Provider>
+    )
+
+    const main_list = screen.getByTestId('asset-pane-main-list')
+    const drag_element = main_list.children[0]
+
+    fireEvent.dragStart(drag_element, {
+      dataTransfer: { setDragImage: () => undefined, setData: () => undefined }
+    }) // Start a drag, mock the dataTransfer object to avoid errors
+
+    let ghost = screen.queryByTestId('asset-ghost') // Look for the ghost
+    expect(ghost).toBeTruthy() // Ghost should exist
+
+    fireEvent.dragEnd(drag_element) // End the drag
+
+    ghost = screen.queryByTestId('asset-ghost') // Look again for the ghost
+    expect(screen.queryByTestId('asset-ghost')).toBeNull() // Should be null because the ghost is removed
   })
 })

--- a/tests/fixtures/constants.ts
+++ b/tests/fixtures/constants.ts
@@ -3,6 +3,8 @@
 export const art_asset: ArtAsset = {
   id: 'e4bd2ad9-6411-4815-b415-d4e37456c499',
   name: 'Some Asset',
+  width: 50,
+  height: 50,
   src: '/tests/fixtures/artwork/some-asset.svg',
   content: {
     name: 'svg',
@@ -23,6 +25,8 @@ export const art_assets: ArtAsset[] = [
   {
     id: 'a6d8dfbf-b154-41f5-8a85-d5fc109bf5b2',
     name: 'Some Second Asset',
+    width: 50,
+    height: 50,
     src: '/tests/fixtures/artwork/some-second-asset.svg',
     content: {
       name: 'svg',


### PR DESCRIPTION
## Summary

This PR adds the ability to drag an asset from the asset pane and drop it onto the stage. When dragging, a ghost image of the asset is created to give the user a visual indicator where the asset will show up in the project when dropped.