### PR TITLE
Persist the project stage state to localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-konva": "^18.2.2",
-    "react-redux": "^8.0.4"
+    "react-redux": "^8.0.4",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ specifiers:
   react-dom: ^18.2.0
   react-konva: ^18.2.2
   react-redux: ^8.0.4
+  redux-persist: ^6.0.0
   svgson: ^5.2.1
   tailwindcss: ^3.1.8
   tailwindcss-gridlines: ^0.2.4
@@ -50,6 +51,7 @@ dependencies:
   react-dom: 18.2.0_react@18.2.0
   react-konva: 18.2.2_ycsaxglfwmvsphhhrpeabwxklq
   react-redux: 8.0.4_5uumaiclxbdbzaqafclbf6maf4
+  redux-persist: 6.0.0_react@18.2.0
 
 devDependencies:
   '@tailwindcss/forms': 0.5.3_tailwindcss@3.1.8
@@ -4259,6 +4261,18 @@ packages:
       css-unit-converter: 1.1.2
       postcss-value-parser: 3.3.1
     dev: true
+
+  /redux-persist/6.0.0_react@18.2.0:
+    resolution: {integrity: sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==}
+    peerDependencies:
+      react: '>=16'
+      redux: '>4.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /redux-thunk/2.4.1_redux@4.2.0:
     resolution: {integrity: sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==}

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -15,7 +15,7 @@ import { useArtAssets } from '../../contexts/assets'
 import { Stage as StageType } from 'konva/lib/Stage'
 import { KonvaEventObject } from 'konva/lib/Node'
 import { ArtAsset, ArtAssetStageObject, StageObjectType } from '../../types'
-import { addObject } from '../../stores/project'
+import { addObject, updateObject } from '../../stores/project'
 
 /**
  * Creates an instance of the visual editor.
@@ -91,6 +91,9 @@ export function Editor({
           )}
           isSelected={selected_asset == stage_object.id}
           onSelect={() => setSelectedAsset(stage_object.id)}
+          onChange={data =>
+            dispatch(updateObject({ id: stage_object.id, data }))
+          }
         />
       )
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,12 +1,24 @@
 ﻿import { configureStore } from '@reduxjs/toolkit'
 import project_reducer from './stores/project'
+import { persistReducer, persistStore } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+
+// Create a persisted version of the project reducer using the localstorage engine from `redux-persist`.
+const persisted_project_reducer = persistReducer(
+  { key: 'project', storage },
+  project_reducer
+)
 
 // Create app-level store
 export const store = configureStore({
   reducer: {
-    project: project_reducer
-  }
+    project: persisted_project_reducer
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({ serializableCheck: false }) // Disable serializable check to suppress warning
 })
+
+export const persistor = persistStore(store)
 
 export type AppDispatch = typeof store.dispatch
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
## Summary

This PR adds `redux-persist` to the project. It is used to wrap the project store and ensures updates to the project are persisted to localstorage when the state updates, as well as restoring the state from localstorage when the page is reloaded.