### PR TITLE
Add save button to editor to export stage as PNG

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -9,13 +9,14 @@ import { PaneHeading } from '../layout/PaneHeading'
 import { EditorAssetPane } from './AssetPane'
 import { Stage, Layer, Rect } from 'react-konva'
 import { useAppDispatch, useAppSelector } from '../../hooks'
-import { isArtAssetStageObject } from '../../utils'
+import { downloadURI, isArtAssetStageObject } from '../../utils'
 import { EditorArtAssetStageObject } from './objects/ArtAssetStageObject'
 import { useArtAssets } from '../../contexts/assets'
 import { Stage as StageType } from 'konva/lib/Stage'
 import { KonvaEventObject } from 'konva/lib/Node'
 import { ArtAsset, ArtAssetStageObject, StageObjectType } from '../../types'
 import { addObject, updateObject } from '../../stores/project'
+import { FlatButton } from '../buttons/FlatButton'
 
 /**
  * Creates an instance of the visual editor.
@@ -132,6 +133,17 @@ export function Editor({
     }
   }
 
+  /**
+   * Save function
+   */
+  /** Save the project as a PNG. */
+  function saveProject() {
+    if (stage_ref.current) {
+      const data_url = stage_ref.current.toDataURL() // Use the stage ref to get the stage canvas' data URL
+      downloadURI(data_url, 'Project.png') // Download it with file name
+    }
+  }
+
   return (
     <div className={className + ' h-full flex'} {...props}>
       {/* Left Pane */}
@@ -139,6 +151,13 @@ export function Editor({
         {/* Assets Pane */}
         <PaneHeading>Assets</PaneHeading>
         <EditorAssetPane className="flex-1" onAssetClick={handleAssetClick} />
+
+        {/* Save */}
+        <div className="p-1/2 bg-neutral-750">
+          <FlatButton className="w-full" onClick={saveProject}>
+            Save Artwork
+          </FlatButton>
+        </div>
       </div>
 
       {/* Main Viewport */}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,3 +6,20 @@ export function isArtAssetStageObject(
 ): object is ArtAssetStageObject {
   return object.type == StageObjectType.ART_ASSET
 }
+
+/**
+ * Downloads a URI automatically.
+ *
+ * Credit: https://stackoverflow.com/questions/3916191/download-data-url-file/15832662
+ */
+export function downloadURI(uri: string, filename: string) {
+  // Create an anchor element setup to download the URI
+  const link = document.createElement('a')
+  link.download = filename
+  link.href = uri
+
+  // Add anchor to body, click it to trigger download, then remove
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}


### PR DESCRIPTION
## Summary

This PR adds a save button to the editor, below the assets pane. This button exports the contents of the stage as a PNG image.