### PR TITLE
Refactor selected asset variables to selected object variables, reorganize editor functions, and fix editor context error message

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -51,6 +51,52 @@ export function Editor({
   }
 
   /**
+   * Drop handling
+   */
+  function handleDrop(e: ReactDragEvent) {
+    if (stage_ref.current) {
+      e.preventDefault()
+
+      stage_ref.current.setPointersPositions(e)
+      const [asset_id, width, height] = e.dataTransfer
+        .getData('text/plain')
+        .split(':') // Deserialize the data transfer object
+
+      // Make sure there is an asset by this ID in the assets list and create the object
+      if (asset_id && art_assets.find(asset => asset.id == asset_id)) {
+        const { x, y } = stage_ref.current.getPointerPosition() || {
+          x: 0,
+          y: 0
+        }
+
+        dispatch(
+          addObject({
+            type: StageObjectType.ART_ASSET,
+            x: x - parseFloat(width) / 2,
+            y: y - parseFloat(height) / 2,
+            scale: { x: 1, y: 1 },
+            rotation: 0,
+            asset_id
+          } as ArtAssetStageObject)
+        )
+      }
+    }
+  }
+
+  /**
+   * Keyboard commands
+   */
+
+  // Delete object
+  useKey(['Delete'], () => {
+    // Make sure an object is selected
+    if (selected_object != undefined) {
+      dispatch(deleteObject(selected_object))
+      setSelectedObject(undefined) // Unset the selected object
+    }
+  })
+
+  /**
    * Stage object selection
    */
   const [selected_object, setSelectedObject] = useState<string | undefined>()
@@ -101,52 +147,6 @@ export function Editor({
           }
         />
       )
-    }
-  })
-
-  /**
-   * Drop handling
-   */
-  function handleDrop(e: ReactDragEvent) {
-    if (stage_ref.current) {
-      e.preventDefault()
-
-      stage_ref.current.setPointersPositions(e)
-      const [asset_id, width, height] = e.dataTransfer
-        .getData('text/plain')
-        .split(':') // Deserialize the data transfer object
-
-      // Make sure there is an asset by this ID in the assets list and create the object
-      if (asset_id && art_assets.find(asset => asset.id == asset_id)) {
-        const { x, y } = stage_ref.current.getPointerPosition() || {
-          x: 0,
-          y: 0
-        }
-
-        dispatch(
-          addObject({
-            type: StageObjectType.ART_ASSET,
-            x: x - parseFloat(width) / 2,
-            y: y - parseFloat(height) / 2,
-            scale: { x: 1, y: 1 },
-            rotation: 0,
-            asset_id
-          } as ArtAssetStageObject)
-        )
-      }
-    }
-  }
-
-  /**
-   * Keyboard commands
-   */
-
-  // Delete object
-  useKey(['Delete'], () => {
-    // Make sure an object is selected
-    if (selected_object != undefined) {
-      dispatch(deleteObject(selected_object))
-      setSelectedObject(undefined) // Unset the selected object
     }
   })
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -51,13 +51,13 @@ export function Editor({
   }
 
   /**
-   * Asset stage object selection
+   * Stage object selection
    */
-  const [selected_asset, setSelectedAsset] = useState<string | undefined>()
+  const [selected_object, setSelectedObject] = useState<string | undefined>()
 
-  /** Deselect if any asset is currently selected. */
-  function deselectAsset() {
-    setSelectedAsset(undefined)
+  /** Deselect if any object is currently selected. */
+  function deselectObject() {
+    setSelectedObject(undefined)
   }
 
   /** Check to make sure the click is outside the stage and deselect if it is. */
@@ -68,7 +68,7 @@ export function Editor({
       stage_ref.current?.content &&
       (e.target as HTMLDivElement).contains(stage_ref.current?.content)
     )
-      deselectAsset()
+      deselectObject()
   }
 
   /** Make sure the clicked area is an empty part of the stage and deselects if it is. */
@@ -76,7 +76,7 @@ export function Editor({
     e: KonvaEventObject<MouseEvent> | KonvaEventObject<TouchEvent>
   ) {
     if (e.target === e.target.getStage() || e.target.id() == 'stage-background')
-      deselectAsset()
+      deselectObject()
   }
 
   /**
@@ -94,8 +94,8 @@ export function Editor({
           art_asset={art_assets.find(
             asset => asset.id == stage_object.asset_id
           )}
-          isSelected={selected_asset == stage_object.id}
-          onSelect={() => setSelectedAsset(stage_object.id)}
+          isSelected={selected_object == stage_object.id}
+          onSelect={() => setSelectedObject(stage_object.id)}
           onChange={data =>
             dispatch(updateObject({ id: stage_object.id, data }))
           }
@@ -144,9 +144,9 @@ export function Editor({
   // Delete object
   useKey(['Delete'], () => {
     // Make sure an object is selected
-    if (selected_asset != undefined) {
-      dispatch(deleteObject(selected_asset))
-      setSelectedAsset(undefined) // Unset the selected object
+    if (selected_object != undefined) {
+      dispatch(deleteObject(selected_object))
+      setSelectedObject(undefined) // Unset the selected object
     }
   })
 
@@ -163,7 +163,7 @@ export function Editor({
 
   return (
     <EditorContext.Provider
-      value={{ selected_asset, setSelectedAsset, deselectAsset }}
+      value={{ selected_object, setSelectedObject, deselectObject }}
     >
       <div className={className + ' h-full flex'} {...props}>
         {/* Left Pane */}
@@ -211,9 +211,9 @@ export function Editor({
         {/* Right Pane */}
         <div className="flex flex-col w-14 bg-neutral-875">
           {/* Stage Pane */}
-          {selected_asset == undefined && <EditorStagePane />}
+          {selected_object == undefined && <EditorStagePane />}
           {/* Object Pane */}
-          {selected_asset && <EditorObjectPane />}
+          {selected_object && <EditorObjectPane />}
         </div>
       </div>
     </EditorContext.Provider>

--- a/src/components/editor/ObjectPane.tsx
+++ b/src/components/editor/ObjectPane.tsx
@@ -7,15 +7,15 @@ import { deleteObject } from '../../stores/project'
 
 export function EditorObjectPane() {
   const dispatch = useAppDispatch()
-  const { selected_asset, deselectAsset } = useEditorContext()
+  const { selected_object, deselectObject } = useEditorContext()
 
   /**
    * Stage Object Delete
    */
 
   function handleObjectDeleteClick() {
-    if (selected_asset) dispatch(deleteObject(selected_asset))
-    deselectAsset()
+    if (selected_object) dispatch(deleteObject(selected_object))
+    deselectObject()
   }
 
   return (

--- a/src/contexts/editor.tsx
+++ b/src/contexts/editor.tsx
@@ -1,4 +1,4 @@
-﻿import { useContext } from 'react'
+import { useContext } from 'react'
 import { createContext } from 'react'
 
 interface EditorContext {
@@ -12,6 +12,6 @@ export const EditorContext = createContext<EditorContext | undefined>(undefined)
 export function useEditorContext() {
   const context = useContext(EditorContext)
   if (context == undefined)
-    throw new Error('Unable to use art assets outside of component')
+    throw new Error('Unable to use editor context outside of component')
   return context
 }

--- a/src/contexts/editor.tsx
+++ b/src/contexts/editor.tsx
@@ -1,10 +1,10 @@
-import { useContext } from 'react'
+﻿import { useContext } from 'react'
 import { createContext } from 'react'
 
 interface EditorContext {
-  selected_asset?: string
-  setSelectedAsset(asset: string): void
-  deselectAsset(): void
+  selected_object?: string
+  setSelectedObject(object: string): void
+  deselectObject(): void
 }
 
 export const EditorContext = createContext<EditorContext | undefined>(undefined)


### PR DESCRIPTION
## Summary

This PR is to rename the selected 'asset' variables like `selected_asset` and `setSelectedAsset` to the more generic 'object'. This is to make it clear that these could be any object on the stage and not just the 'art asset' type of object.

Additionally, the CRUD-related functions within the Editor are now grouped together, and the error message for the `useEditorContext` has been fixed so it no longer refers to art assets.